### PR TITLE
Ensure messages are ack'd

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -75,7 +75,10 @@ func (s Slack) handleEvent(evt socketmode.Event) (err error) {
 
 			switch ev := innerEvent.Data.(type) {
 			case *slackevents.MessageEvent:
-				return s.handleMessageEvent(ev)
+				err = s.handleMessageEvent(ev)
+				if err != nil {
+					return
+				}
 			}
 		}
 


### PR DESCRIPTION
Prior to this, parsed messages were not ack'd, which meant they ended up spamming the hell out of recipients