### PR TITLE
Upgrade types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gender-equality-community/gec-slacker
 go 1.18
 
 require (
-	github.com/gender-equality-community/types v1.2.0
+	github.com/gender-equality-community/types v1.3.0
 	github.com/go-redis/redis/v9 v9.0.0-beta.2
 	github.com/rs/xid v1.4.0
 	github.com/slack-go/slack v0.11.3

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
-github.com/gender-equality-community/types v1.2.0 h1:mdbkBCHUzHDCKHMlAmnXfC6BiCHca9zyQvNJX9gv7SI=
-github.com/gender-equality-community/types v1.2.0/go.mod h1:zSavH17hq7FtUZysU9m2vwflJzJLcTxe7/OD6V3DB+g=
+github.com/gender-equality-community/types v1.3.0 h1:6K1EJDjCAWDHJPzvZp5wavr6s3mVAeR/XWJuxbZYdwQ=
+github.com/gender-equality-community/types v1.3.0/go.mod h1:zSavH17hq7FtUZysU9m2vwflJzJLcTxe7/OD6V3DB+g=
 github.com/go-redis/redis/v9 v9.0.0-beta.2 h1:ZSr84TsnQyKMAg8gnV+oawuQezeJR11/09THcWCQzr4=
 github.com/go-redis/redis/v9 v9.0.0-beta.2/go.mod h1:Bldcd/M/bm9HbnNPi/LUtYBSD8ttcZYBMupwMXhdU0o=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=


### PR DESCRIPTION
Reading from redis failed with unconvertible type errors, because redis stores stuff as strings.

This updated version of types casts the correct values in the correct way