### PR TITLE
Upgrade to slack v0.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/gender-equality-community/types v1.5.0
 	github.com/go-redis/redis/v9 v9.0.0-rc.2
 	github.com/rs/xid v1.4.0
-	github.com/slack-go/slack v0.11.4
+	github.com/slack-go/slack v0.12.1
 )
 
 require (
-	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
-github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
@@ -25,8 +25,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
-github.com/slack-go/slack v0.11.4 h1:ojSa7KlPm3PqY2AomX4VTxEsK5eci5JaxCjlzGV5zoM=
-github.com/slack-go/slack v0.11.4/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
+github.com/slack-go/slack v0.12.1 h1:X97b9g2hnITDtNsNe5GkGx6O2/Sz/uC20ejRZN6QxOw=
+github.com/slack-go/slack v0.12.1/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 golang.org/x/net v0.2.0 h1:sZfSu1wtKLGlWI4ZZayP0ck9Y73K1ynO6gqzTdBVdPU=

--- a/slack.go
+++ b/slack.go
@@ -22,9 +22,9 @@ type socketmodeClient interface {
 type slackClient interface {
 	PostMessage(string, ...slack.MsgOption) (string, string, error)
 	GetConversations(*slack.GetConversationsParameters) ([]slack.Channel, string, error)
-	CreateConversation(string, bool) (*slack.Channel, error)
+	CreateConversation(slack.CreateConversationParams) (*slack.Channel, error)
 	JoinConversation(string) (*slack.Channel, string, []string, error)
-	GetConversationInfo(string, bool) (*slack.Channel, error)
+	GetConversationInfo(*slack.GetConversationInfoInput) (*slack.Channel, error)
 }
 
 type Slack struct {
@@ -163,7 +163,9 @@ func (s Slack) Send(m types.Message) (err error) {
 }
 
 func (s Slack) chanName(id string) (name string, err error) {
-	c, err := s.slack.GetConversationInfo(id, false)
+	c, err := s.slack.GetConversationInfo(&slack.GetConversationInfoInput{
+		ChannelID: id,
+	})
 	if err != nil {
 		return
 	}
@@ -189,7 +191,10 @@ func (s Slack) chanID(user string) (id string, err error) {
 }
 
 func (s Slack) newChannel(user string) (id string, err error) {
-	c, err := s.slack.CreateConversation(user, false)
+	c, err := s.slack.CreateConversation(slack.CreateConversationParams{
+		ChannelName: user,
+		IsPrivate:   false,
+	})
 	if err != nil {
 		return
 	}

--- a/slack_test.go
+++ b/slack_test.go
@@ -59,7 +59,7 @@ func (d *dummySlackClient) GetConversations(*slack.GetConversationsParameters) (
 	}, "", nil
 }
 
-func (d *dummySlackClient) CreateConversation(string, bool) (*slack.Channel, error) {
+func (d *dummySlackClient) CreateConversation(slack.CreateConversationParams) (*slack.Channel, error) {
 	if d.error {
 		return nil, fmt.Errorf("an error")
 	}
@@ -82,9 +82,9 @@ func (d *dummySlackClient) JoinConversation(string) (*slack.Channel, string, []s
 	return nil, "", nil, nil
 }
 
-func (d *dummySlackClient) GetConversationInfo(string, bool) (*slack.Channel, error) {
+func (d *dummySlackClient) GetConversationInfo(*slack.GetConversationInfoInput) (*slack.Channel, error) {
 	// same signature and data, be a little lazy
-	return d.CreateConversation("", false)
+	return d.CreateConversation(slack.CreateConversationParams{})
 }
 
 func TestNewSlack(t *testing.T) {


### PR DESCRIPTION
We get a series of benefits and added metadata with slack v0.12 (up from v0.11), but this change brings a series of backwards incompatible changes around inputs to various functions.

This change makes a series of manual fixes, in essence, to the PR that dependabot opened in https://github.com/gender-equality-community/gec-slacker/pull/18